### PR TITLE
Fix the bug after presented the from view disappear

### DIFF
--- a/Sources/FlowingMenuTransitionManager+UIViewControllerAnimatedTransitioning.swift
+++ b/Sources/FlowingMenuTransitionManager+UIViewControllerAnimatedTransitioning.swift
@@ -48,7 +48,13 @@ extension FlowingMenuTransitionManager: UIViewControllerAnimatedTransitioning {
     let status = FlowingMenuTransitionStatus(context: context)
 
     action(menuView!, otherView!, containerView, status, transitionDuration(using: context)) {
+      let canceled = context.transitionWasCancelled
       context.completeTransition(!context.transitionWasCancelled)
+      if (!canceled) {
+            if self.animationMode == .presentation {
+                UIApplication.shared.keyWindow?.insertSubview(fromVC!.view, at:0)
+            }
+        }
     }
   }
 


### PR DESCRIPTION
Run by Xcode 8, after presented, the view of from view controller will disappear, and just a gray view remained.
